### PR TITLE
Constants that are deprecated are updated.

### DIFF
--- a/src/Infrastructure/LoggerFactory.php
+++ b/src/Infrastructure/LoggerFactory.php
@@ -6,6 +6,7 @@ namespace App\Infrastructure;
 
 use Devanych\Di\FactoryInterface;
 use Exception;
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Psr\Container\ContainerInterface;
@@ -29,7 +30,7 @@ final class LoggerFactory implements FactoryInterface
 
         $logger->pushHandler(new StreamHandler(
             $config['log_file'],
-            $config['debug'] ? Logger::DEBUG : Logger::WARNING
+            $config['debug'] ? Level::Debug : Level::Warning
         ));
 
         return $logger;


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | Constant 'Logger::DEBUG' is deprecated.
|   | Constant 'Logger::WARNING' is deprecated. 
|   | [/Monolog/Logger.php#L37](https://github.com/Seldaek/monolog/blob/1dacc790b9cdbbac11dacc089937f6e2fa75130d/src/Monolog/Logger.php#L37)
